### PR TITLE
[More Helpful Warnings] More helpful/human-readable warnings for edge cases

### DIFF
--- a/depz/depz.py
+++ b/depz/depz.py
@@ -631,7 +631,7 @@ def main ():
   global log_is_tty
   log_is_tty = sys.stderr.isatty()
 
-  logging.basicConfig(level=logging.DEBUG)
+  logging.basicConfig(level=logging.DEBUG,format="%(levelname)-8s %(name)-20s %(message)s")
   log = logging.getLogger("depz")
 
   init_config()


### PR DESCRIPTION
- Additional suggestions for when branch is ahead and/or behind origin.
- Warning message and graceful exit when branch is in detached head state.
- Correct pluralization of file/files and commit/commits in messages.
- Bug fix: "X commits ahead" message was using 'behind' count instead of 'ahead'.